### PR TITLE
Allow default commands to take options and/or arguments.

### DIFF
--- a/src/main/java/io/airlift/command/Parser.java
+++ b/src/main/java/io/airlift/command/Parser.java
@@ -62,19 +62,29 @@ public class Parser
         if (tokens.hasNext()) {
             CommandMetadata command = find(expectedCommands, compose(equalTo(tokens.peek()), CommandMetadata.nameGetter()), null);
             if (command == null) {
-                while (tokens.hasNext()) {
-                    state = state.withUnparsedInput(tokens.next());
+                if (state.getGroup() != null && state.getGroup().getDefaultCommand() != null) {
+                    state = state.withCommand(state.getGroup().getDefaultCommand());
+                }
+                else {
+                    state = state.withCommand(metadata.getDefaultCommand());
                 }
             }
             else {
                 tokens.next();
                 state = state.withCommand(command).pushContext(Context.COMMAND);
+            }
+        }
 
-                while (tokens.hasNext()) {
-                    state = parseOptions(tokens, state, command.getCommandOptions());
-
-                    state = parseArgs(state, tokens, command.getArguments());
-                }
+        if (state.getCommand() == null) {
+             while (tokens.hasNext()) {
+                state = state.withUnparsedInput(tokens.next());
+             }
+        }
+        else {
+            CommandMetadata command = state.getCommand();
+            while (tokens.hasNext()) {
+                state = parseOptions(tokens, state, command.getCommandOptions());
+                state = parseArgs(state, tokens, command.getArguments());
             }
         }
 

--- a/src/test/java/io/airlift/command/CommandTest.java
+++ b/src/test/java/io/airlift/command/CommandTest.java
@@ -49,6 +49,7 @@ import static com.google.common.base.Predicates.compose;
 import static com.google.common.base.Predicates.equalTo;
 import static com.google.common.collect.Iterables.find;
 import static io.airlift.command.TestUtil.singleCommandParser;
+import static io.airlift.command.TestUtil.singleCommandParserWithDefault;
 
 @Test
 public class CommandTest
@@ -68,6 +69,22 @@ public class CommandTest
         Assert.assertEquals(args.doub, 1.3f, 0.1f);
         Assert.assertEquals(args.bigd, new BigDecimal("1.4"));
     }
+
+  public void simpleArgsWithDefault()
+          throws ParseException
+  {
+      Args1 args = singleCommandParserWithDefault(Args1.class).parse(
+              "-debug", "-log", "2", "-float", "1.2", "-double", "1.3", "-bigdecimal", "1.4",
+              "-groups", "unit", "a", "b", "c");
+
+      Assert.assertTrue(args.debug);
+      Assert.assertEquals(args.verbose.intValue(), 2);
+      Assert.assertEquals(args.groups, "unit");
+      Assert.assertEquals(args.parameters, Arrays.asList("a", "b", "c"));
+      Assert.assertEquals(args.floa, 1.2f, 0.1f);
+      Assert.assertEquals(args.doub, 1.3f, 0.1f);
+      Assert.assertEquals(args.bigd, new BigDecimal("1.4"));
+  }
 
     public void equalsArgs()
             throws ParseException

--- a/src/test/java/io/airlift/command/TestUtil.java
+++ b/src/test/java/io/airlift/command/TestUtil.java
@@ -8,4 +8,13 @@ public class TestUtil
                 .withCommand(commandClass)
                 .build();
     }
+
+    public static <T> Cli<T> singleCommandParserWithDefault(Class<T> commandClass)
+    {
+         return Cli.<T>builder("parser")
+                .withCommand(commandClass)
+                .withDefaultCommand(commandClass)
+                .build();
+    }
+
 }


### PR DESCRIPTION
1) Adjust Parser to determine default commands as part of the parsing so that they can get options and arguments injected as well
