### PR TITLE
add exception when an option or argument annotated on a final field.

### DIFF
--- a/src/main/java/io/airlift/airline/FieldIsFinalException.java
+++ b/src/main/java/io/airlift/airline/FieldIsFinalException.java
@@ -1,0 +1,13 @@
+package io.airlift.airline;
+
+/**
+ * Created by zhxiaog on 15-3-22.
+ */
+public class FieldIsFinalException
+        extends RuntimeException
+{
+    public FieldIsFinalException(String clsName, String fieldName, String metadataType)
+    {
+        super(String.format("Found %s on final field %s#%s.", metadataType, clsName, fieldName));
+    }
+}

--- a/src/main/java/io/airlift/airline/model/MetadataLoader.java
+++ b/src/main/java/io/airlift/airline/model/MetadataLoader.java
@@ -126,7 +126,7 @@ public class MetadataLoader
 
                 Inject injectAnnotation = field.getAnnotation(Inject.class);
                 if (injectAnnotation != null) {
-                    checkNotFinal("injection", field);
+                    // checkNotFinal("injection", field);
                     if (field.getType().equals(GlobalMetadata.class) ||
                             field.getType().equals(CommandGroupMetadata.class) ||
                             field.getType().equals(CommandMetadata.class)) {

--- a/src/main/java/io/airlift/airline/model/MetadataLoader.java
+++ b/src/main/java/io/airlift/airline/model/MetadataLoader.java
@@ -9,17 +9,21 @@ import com.google.common.collect.ListMultimap;
 import io.airlift.airline.Accessor;
 import io.airlift.airline.Arguments;
 import io.airlift.airline.Command;
+import io.airlift.airline.FieldIsFinalException;
 import io.airlift.airline.Option;
 import io.airlift.airline.OptionType;
 import io.airlift.airline.Suggester;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.common.collect.Iterables.toString;
 import static com.google.common.collect.Iterables.transform;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
@@ -122,6 +126,7 @@ public class MetadataLoader
 
                 Inject injectAnnotation = field.getAnnotation(Inject.class);
                 if (injectAnnotation != null) {
+                    checkNotFinal("injection", field);
                     if (field.getType().equals(GlobalMetadata.class) ||
                             field.getType().equals(CommandGroupMetadata.class) ||
                             field.getType().equals(CommandMetadata.class)) {
@@ -133,6 +138,7 @@ public class MetadataLoader
 
                 Option optionAnnotation = field.getAnnotation(Option.class);
                 if (optionAnnotation != null) {
+                    checkNotFinal("option", field);
                     OptionType optionType = optionAnnotation.type();
                     String name;
                     if (!optionAnnotation.title().isEmpty()) {
@@ -184,6 +190,7 @@ public class MetadataLoader
 
                 Arguments argumentsAnnotation = field.getAnnotation(Arguments.class);
                 if (field.isAnnotationPresent(Arguments.class)) {
+                    checkNotFinal("argument", field);
                     String title;
                     if (!argumentsAnnotation.title().isEmpty()) {
                         title = argumentsAnnotation.title();
@@ -237,6 +244,12 @@ public class MetadataLoader
     private static <T> ImmutableList<T> concat(Iterable<T> iterable, T item)
     {
         return ImmutableList.<T>builder().addAll(iterable).add(item).build();
+    }
+
+    private static void checkNotFinal(String metadataType, Field field) {
+        if(Modifier.isFinal(field.getModifiers())) {
+            throw new FieldIsFinalException(field.getDeclaringClass().getCanonicalName(), field.getName(), metadataType);
+        }
     }
 
     private static class InjectionMetadata

--- a/src/test/java/io/airlift/airline/TestGalaxyCommandLineParser.java
+++ b/src/test/java/io/airlift/airline/TestGalaxyCommandLineParser.java
@@ -141,16 +141,16 @@ public class TestGalaxyCommandLineParser
     public static class AgentFilter
     {
         @Option(name = {"-i", "--host"}, description = "Select slots on the given host")
-        public final List<String> host = newArrayList();
+        public List<String> host = newArrayList();
 
         @Option(name = {"-I", "--ip"}, description = "Select slots at the given IP address")
-        public final List<String> ip = newArrayList();
+        public List<String> ip = newArrayList();
 
         @Option(name = {"-u", "--uuid"}, description = "Select slot with the given UUID")
-        public final List<String> uuid = newArrayList();
+        public List<String> uuid = newArrayList();
 
         @Option(name = {"-s", "--state"}, description = "Select 'r{unning}', 's{topped}' or 'unknown' slots")
-        public final List<String> state = newArrayList();
+        public List<String> state = newArrayList();
 
         @Override
         public String toString()
@@ -218,7 +218,7 @@ public class TestGalaxyCommandLineParser
 
         @Arguments(usage = "<groupId:artifactId[:packaging[:classifier]]:version> @<component:pools:version>",
                 description = "The binary and @configuration to install.  The default packaging is tar.gz")
-        public final List<String> assignment = Lists.newArrayList();
+        public List<String> assignment = Lists.newArrayList();
 
         @Override
         public String toString()
@@ -241,7 +241,7 @@ public class TestGalaxyCommandLineParser
 
         @Arguments(usage = "[<binary-version>] [@<config-version>]",
                 description = "Version of the binary and/or @configuration")
-        public final List<String> versions = Lists.newArrayList();
+        public List<String> versions = Lists.newArrayList();
 
         @Override
         public String toString()


### PR DESCRIPTION
hi,
    When writing a command, if annotations of option or argument annotated on a final field, it will complain nothing and will start up successfully without parameters taking effect.