### PR TITLE
Command Factory Support

### DIFF
--- a/src/main/java/io/airlift/airline/Cli.java
+++ b/src/main/java/io/airlift/airline/Cli.java
@@ -18,24 +18,25 @@
 
 package io.airlift.airline;
 
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newHashMap;
+import static io.airlift.airline.ParserUtil.createInstance;
+
+import java.util.List;
+import java.util.Map;
+
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+
 import io.airlift.airline.model.ArgumentsMetadata;
 import io.airlift.airline.model.CommandGroupMetadata;
 import io.airlift.airline.model.CommandMetadata;
 import io.airlift.airline.model.GlobalMetadata;
 import io.airlift.airline.model.MetadataLoader;
 import io.airlift.airline.model.OptionMetadata;
-
-import java.util.List;
-import java.util.Map;
-
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Maps.newHashMap;
-import static io.airlift.airline.ParserUtil.createInstance;
 
 public class Cli<C>
 {
@@ -78,6 +79,7 @@ public class Cli<C>
 
         List<CommandGroupMetadata> commandGroups = ImmutableList.copyOf(Iterables.transform(groups, new Function<GroupBuilder<C>, CommandGroupMetadata>()
         {
+            @Override
             public CommandGroupMetadata apply(GroupBuilder<C> group)
             {
                 return MetadataLoader.loadCommandGroup(group.name, group.description, MetadataLoader.loadCommand(group.defaultCommand), MetadataLoader.loadCommands(group.commands));
@@ -136,6 +138,39 @@ public class Cli<C>
                 ImmutableMap.<Class<?>, Object>of(GlobalMetadata.class, metadata),
                 commandFactory);
     }
+
+    public C parse(C commandInstance, String... args)
+    {
+        Preconditions.checkNotNull(args, "args is null");
+        
+        Parser parser = new Parser();
+        ParseState state = parser.parse(metadata, args);
+
+        if (state.getCommand() == null) {
+            if (state.getGroup() != null) {
+                state = state.withCommand(state.getGroup().getDefaultCommand());
+            }
+            else {
+                state = state.withCommand(metadata.getDefaultCommand());
+            }
+        }
+
+        validate(state);
+
+        CommandMetadata command = state.getCommand();
+
+        C c = ParserUtil.injectOptions(commandInstance,
+            command.getAllOptions(),
+            state.getParsedOptions(),
+            command.getArguments(),
+            state.getParsedArguments(),
+            command.getMetadataInjections(),
+            ImmutableMap.<Class<?>, Object>of(GlobalMetadata.class, metadata));
+        
+        return c;
+    }
+    
+    
     
     private void validate(ParseState state)
     {

--- a/src/main/java/io/airlift/airline/Cli.java
+++ b/src/main/java/io/airlift/airline/Cli.java
@@ -92,12 +92,22 @@ public class Cli<C>
         return metadata;
     }
 
+    public C parse(CommandFactory<C> commandFactory, String... args)
+    {
+        return parse(commandFactory, ImmutableList.copyOf(args));
+    }    
+    
     public C parse(String... args)
     {
-        return parse(ImmutableList.copyOf(args));
+        return parse(new CommandFactoryDefault<C>(), ImmutableList.copyOf(args));
     }
-    
-    public C parse(Iterable<String> args)
+
+    public C parse(Iterable<String> args) 
+    {
+        return parse(new CommandFactoryDefault<C>(), args);
+    }
+
+    public C parse(CommandFactory<C> commandFactory, Iterable<String> args)
     {
         Preconditions.checkNotNull(args, "args is null");
         
@@ -123,7 +133,8 @@ public class Cli<C>
                 command.getArguments(),
                 state.getParsedArguments(),
                 command.getMetadataInjections(),
-                ImmutableMap.<Class<?>, Object>of(GlobalMetadata.class, metadata));
+                ImmutableMap.<Class<?>, Object>of(GlobalMetadata.class, metadata),
+                commandFactory);
     }
     
     private void validate(ParseState state)
@@ -172,6 +183,7 @@ public class Cli<C>
         private Class<? extends C> defaultCommand;
         private final List<Class<? extends C>> defaultCommandGroupCommands = newArrayList();
         protected final Map<String, GroupBuilder<C>> groups = newHashMap();
+        protected CommandFactory<C> commandFactory;
 
         public CliBuilder(String name)
         {
@@ -185,6 +197,12 @@ public class Cli<C>
             Preconditions.checkNotNull(description, "description is null");
             Preconditions.checkArgument(!description.isEmpty(), "description is empty");
             this.description = description;
+            return this;
+        }
+        
+        public CliBuilder<C> withCommandFactory(CommandFactory<C> commandFactory) 
+        {
+            this.commandFactory = commandFactory;
             return this;
         }
 

--- a/src/main/java/io/airlift/airline/CommandFactory.java
+++ b/src/main/java/io/airlift/airline/CommandFactory.java
@@ -1,0 +1,5 @@
+package io.airlift.airline;
+
+public interface CommandFactory<T> {
+  T createInstance(Class<?> type);
+}

--- a/src/main/java/io/airlift/airline/CommandFactoryDefault.java
+++ b/src/main/java/io/airlift/airline/CommandFactoryDefault.java
@@ -1,0 +1,10 @@
+package io.airlift.airline;
+
+public class CommandFactoryDefault<T> implements CommandFactory<T> {
+
+  @Override
+  public T createInstance(Class<?> type) {
+    return (T) ParserUtil.createInstance(type);
+  }
+  
+}

--- a/src/main/java/io/airlift/airline/ParserUtil.java
+++ b/src/main/java/io/airlift/airline/ParserUtil.java
@@ -26,15 +26,28 @@ public class ParserUtil
     }
 
     public static <T> T createInstance(Class<?> type,
+        Iterable<OptionMetadata> options,
+        ListMultimap<OptionMetadata, Object> parsedOptions,
+        ArgumentsMetadata arguments,
+        Iterable<Object> parsedArguments,
+        Iterable<Accessor> metadataInjection,
+        Map<Class<?>, Object> bindings)
+    {
+        return createInstance(type, options, parsedOptions, arguments, parsedArguments, metadataInjection, bindings, new CommandFactoryDefault<T>());
+    }
+    
+    
+    public static <T> T createInstance(Class<?> type,
             Iterable<OptionMetadata> options,
             ListMultimap<OptionMetadata, Object> parsedOptions,
             ArgumentsMetadata arguments,
             Iterable<Object> parsedArguments,
             Iterable<Accessor> metadataInjection,
-            Map<Class<?>, Object> bindings)
+            Map<Class<?>, Object> bindings,
+            CommandFactory<T> commandFactory)
     {
         // create the command instance
-        T commandInstance = (T) ParserUtil.createInstance(type);
+        T commandInstance = (T) commandFactory.createInstance(type);
 
         // inject options
         for (OptionMetadata option : options) {

--- a/src/main/java/io/airlift/airline/ParserUtil.java
+++ b/src/main/java/io/airlift/airline/ParserUtil.java
@@ -37,18 +37,14 @@ public class ParserUtil
     }
     
     
-    public static <T> T createInstance(Class<?> type,
-            Iterable<OptionMetadata> options,
-            ListMultimap<OptionMetadata, Object> parsedOptions,
-            ArgumentsMetadata arguments,
-            Iterable<Object> parsedArguments,
-            Iterable<Accessor> metadataInjection,
-            Map<Class<?>, Object> bindings,
-            CommandFactory<T> commandFactory)
-    {
-        // create the command instance
-        T commandInstance = (T) commandFactory.createInstance(type);
-
+    public static <T> T injectOptions(T commandInstance,
+        Iterable<OptionMetadata> options,
+        ListMultimap<OptionMetadata, Object> parsedOptions,
+        ArgumentsMetadata arguments,
+        Iterable<Object> parsedArguments,
+        Iterable<Accessor> metadataInjection,
+        Map<Class<?>, Object> bindings)
+    {      
         // inject options
         for (OptionMetadata option : options) {
             List<?> values = parsedOptions.get(option);
@@ -62,23 +58,38 @@ public class ParserUtil
                 }
             }
         }
-
+  
         // inject args
         if (arguments != null && parsedArguments != null) {
             for (Accessor accessor : arguments.getAccessors()) {
                 accessor.addValues(commandInstance, parsedArguments);
             }
         }
-
+  
         for (Accessor accessor : metadataInjection) {
             Object injectee = bindings.get(accessor.getJavaType());
-
+  
             if (injectee != null) {
                 accessor.addValues(commandInstance, ImmutableList.of(injectee));
             }
         }
-
+  
         return commandInstance;
     }
+    
+    
+    public static <T> T createInstance(Class<?> type,
+            Iterable<OptionMetadata> options,
+            ListMultimap<OptionMetadata, Object> parsedOptions,
+            ArgumentsMetadata arguments,
+            Iterable<Object> parsedArguments,
+            Iterable<Accessor> metadataInjection,
+            Map<Class<?>, Object> bindings,
+            CommandFactory<T> commandFactory)
+    {
+        // create the command instance
+        T commandInstance = (T) commandFactory.createInstance(type);
 
+        return injectOptions(commandInstance, options, parsedOptions, arguments, parsedArguments, metadataInjection, bindings);        
+    }
 }


### PR DESCRIPTION
Allow commands to be created by a factory, like Guice or Dagger, and allow those commands to be reconfigured if desired.