### PR TITLE
Upgrade to Airbase 45 to fix Java 8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: java
+
+jdk:
+  - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: java
 
 jdk:
   - oraclejdk8
+
+sudo: false

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>28</version>
+        <version>45</version>
     </parent>
 
     <artifactId>airline</artifactId>


### PR DESCRIPTION
Previous version of Jacoco could not parse Java8 byte code and would fail the build.

Fixes #46