### PR TITLE
Add @SafeVarargs annotation to Cli.java

### DIFF
--- a/src/main/java/io/airlift/airline/Cli.java
+++ b/src/main/java/io/airlift/airline/Cli.java
@@ -264,7 +264,8 @@ public class Cli<C>
             return this;
         }
 
-        public CliBuilder<C> withCommands(Class<? extends C> command, Class<? extends C>... moreCommands)
+        @SafeVarargs
+        public final CliBuilder<C> withCommands(Class<? extends C> command, Class<? extends C>... moreCommands)
         {
             this.defaultCommandGroupCommands.add(command);
             this.defaultCommandGroupCommands.addAll(ImmutableList.copyOf(moreCommands));
@@ -335,7 +336,8 @@ public class Cli<C>
             return this;
         }
 
-        public GroupBuilder<C> withCommands(Class<? extends C> command, Class<? extends C>... moreCommands)
+        @SafeVarargs
+        public final GroupBuilder<C> withCommands(Class<? extends C> command, Class<? extends C>... moreCommands)
         {
             this.commands.add(command);
             this.commands.addAll(ImmutableList.copyOf(moreCommands));


### PR DESCRIPTION
Summary:

Cli.CliBuilder and Cli.GroupBuilder have

    public CliBuilder<C> withCommands(Class<? extends C> command, Class<? extends C>... moreCommands);

    public GroupBuilder<C> withCommands(Class<? extends C> command, Class<? extends C>... moreCommands)

Both of them use the `moreCommands` array in a typesafe way, which means
they could be annotated with @SafeVarargs. They were not, though, which
generates unchecked warnings at call sites.

Note that the methods must be made final for SafeVarargs to be valid.

A description of SafeVarargs is
https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.6.4.7

Test plan: `mvn clean verify` passes on 8u141